### PR TITLE
NGC-939: Return a 400 Bad Request when the OS sent in a version check POST is not recognised

### DIFF
--- a/app/uk/gov/hmrc/customerprofile/controllers/NativeVersionCheckerController.scala
+++ b/app/uk/gov/hmrc/customerprofile/controllers/NativeVersionCheckerController.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.customerprofile.controllers
 
 import play.api.Logger
-import play.api.libs.json.Json
+import play.api.libs.json.{JsError, Json}
 import play.api.mvc.BodyParsers
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-import uk.gov.hmrc.api.controllers.{ErrorGenericBadRequest, ErrorResponse, HeaderValidator}
+import uk.gov.hmrc.api.controllers.HeaderValidator
 import uk.gov.hmrc.customerprofile.controllers.action.{AccountAccessControlCheckOff, AccountAccessControlWithHeaderCheck}
 import uk.gov.hmrc.customerprofile.domain.DeviceVersion
 import uk.gov.hmrc.customerprofile.services.{LiveUpgradeRequiredCheckerService, SandboxUpgradeRequiredCheckerService, UpgradeRequiredCheckerService}
 import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 import scala.concurrent.Future
@@ -37,7 +37,6 @@ object UpgradeRequired {
 trait NativeVersionCheckerController extends BaseController with HeaderValidator with ErrorHandling {
 
   import DeviceVersion.formats
-  import ErrorResponse.writes
   import UpgradeRequired.formats
 
   val upgradeRequiredCheckerService : UpgradeRequiredCheckerService
@@ -51,7 +50,7 @@ trait NativeVersionCheckerController extends BaseController with HeaderValidator
       request.body.validate[DeviceVersion].fold(
         errors => {
           Logger.warn("Received error with service validate app version: " + errors)
-          Future.successful(BadRequest(Json.toJson(ErrorGenericBadRequest(errors))))
+          Future.successful(BadRequest(JsError.toJson(errors)))
         },
         deviceVersion => {
           errorWrapper(upgradeRequiredCheckerService.upgradeRequired(deviceVersion).map {

--- a/app/uk/gov/hmrc/customerprofile/domain/ApprovedAppVersions.scala
+++ b/app/uk/gov/hmrc/customerprofile/domain/ApprovedAppVersions.scala
@@ -86,7 +86,7 @@ object NativeOS {
       case JsString("ios") => JsSuccess(iOS)
       case JsString("android") => JsSuccess(Android)
       case JsString("windows") => JsSuccess(Windows)
-      case _ => JsError()
+      case _ => JsError("unknown os")
     }
   }
 

--- a/test/uk/gov/hmrc/customerprofile/controllers/NativeVersionCheckerSpec.scala
+++ b/test/uk/gov/hmrc/customerprofile/controllers/NativeVersionCheckerSpec.scala
@@ -41,6 +41,13 @@ class NativeVersionCheckerSpec extends UnitSpec with ScalaFutures with StubAppli
       status(result) shouldBe 200
       contentAsJson(result) shouldBe upgradeTrue
     }
+
+    "return 400 when a version check is attempted with an unknown OS" in new SuccessNativeVersionChecker {
+      val result = await(controller.validateAppVersion(None)(jsonUnknownDeviceOSRequest))
+
+      status(result) shouldBe 400
+      contentAsJson(result) shouldBe unknownOS
+    }
   }
 
   "nativeVersionChecker Sandbox controller " should {

--- a/test/uk/gov/hmrc/customerprofile/controllers/Setup.scala
+++ b/test/uk/gov/hmrc/customerprofile/controllers/Setup.scala
@@ -131,11 +131,13 @@ trait Setup {
 
   val upgradeFalse = Json.parse("""{"upgrade":false}""")
   val upgradeTrue = Json.parse("""{"upgrade":true}""")
+  val unknownOS = Json.parse("""{"obj.os":[{"msg":["unknown os"],"args":[]}]}""")
 
   val preferenceSuccess = Json.parse("""{"digital":true,"email":{"email":"name@email.co.uk","status":"verified"}}""")
 
   val deviceVersion = DeviceVersion(Android, "1.0.1")
   lazy val jsonDeviceVersionRequest = fakeRequest(Json.toJson(deviceVersion)).withHeaders(acceptHeader)
+  lazy val jsonUnknownDeviceOSRequest = fakeRequest(Json.parse("""{"os":"unicorn","version":"1.2.3"}""")).withHeaders(acceptHeader)
 
   lazy val http200ResponseCid = Future.successful(HttpResponse(200, Some(Json.toJson(person))))
 


### PR DESCRIPTION
Return BadRequest when a version check is attempted with an unknown OS