### PR TITLE
Hma 9109

### DIFF
--- a/app/uk/gov/hmrc/customerprofile/connector/GooglePassConnector.scala
+++ b/app/uk/gov/hmrc/customerprofile/connector/GooglePassConnector.scala
@@ -75,4 +75,24 @@ class GooglePassConnector @Inject() (
       }
   }
 
+  def getGoogleQRCode(
+    passId:        String
+  )(implicit ec:   ExecutionContext,
+    headerCarrier: HeaderCarrier
+  ): Future[RetrieveGooglePass] = {
+
+    val url = s"$findMyNinoAddToWalletUrl/find-my-nino-add-to-wallet/get-google-qr-code ?passId=$passId"
+
+    http
+      .get(url"$url")
+      .execute[HttpResponse]
+      .map { response =>
+        response.status match {
+          case OK =>
+            RetrieveGooglePass(response.body)
+          case _ => throw new HttpException(response.body, response.status)
+        }
+      }
+  }
+
 }

--- a/app/uk/gov/hmrc/customerprofile/controllers/ApplePassController.scala
+++ b/app/uk/gov/hmrc/customerprofile/controllers/ApplePassController.scala
@@ -62,4 +62,19 @@ class ApplePassController @Inject() (
         }
       }
     }
+
+  def getAppleQRCode(journeyId: JourneyId): Action[AnyContent] =
+    validateAcceptWithAuth(acceptHeaderValidationRules, None).async { implicit request =>
+      implicit val hc: HeaderCarrier = fromRequest(request)
+      shutteringConnector.getShutteringStatus(journeyId).flatMap { shuttered =>
+        withShuttering(shuttered) {
+          errorWrapper {
+            service
+              .getAppleQRCode()
+              .map(response => Ok(toJson(response)))
+          }
+        }
+      }
+    }
+
 }

--- a/app/uk/gov/hmrc/customerprofile/controllers/GooglePassController.scala
+++ b/app/uk/gov/hmrc/customerprofile/controllers/GooglePassController.scala
@@ -62,4 +62,18 @@ class GooglePassController @Inject() (
         }
       }
     }
+
+  def getGoogleQRCode(journeyId: JourneyId): Action[AnyContent] =
+    validateAcceptWithAuth(acceptHeaderValidationRules, None).async { implicit request =>
+      implicit val hc: HeaderCarrier = fromRequest(request)
+      shutteringConnector.getShutteringStatus(journeyId).flatMap { shuttered =>
+        withShuttering(shuttered) {
+          errorWrapper {
+            service
+              .getGoogleQRCode()
+              .map(response => Ok(toJson(response)))
+          }
+        }
+      }
+    }
 }

--- a/app/uk/gov/hmrc/customerprofile/services/ApplePassService.scala
+++ b/app/uk/gov/hmrc/customerprofile/services/ApplePassService.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.customerprofile.controllers.NinoNotFoundOnAccount
 import uk.gov.hmrc.customerprofile.domain.RetrieveApplePass
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
 import javax.inject.Named
 import scala.concurrent.{ExecutionContext, Future}
@@ -55,6 +54,20 @@ class ApplePassService @Inject() (
                                                                     citizenDetails.person.completeName)
         getApplePass <- createApplePassConnector.getApplePass(createApplePass)
       } yield getApplePass
+    }
+
+  def getAppleQRCode(
+  )(implicit hc:      HeaderCarrier,
+    executionContext: ExecutionContext
+  ): Future[Option[Array[Byte]]] =
+    auditService.withAudit("appleQRCode", Map.empty) {
+      for {
+        nino           <- getNino()
+        citizenDetails <- citizenDetailsConnector.personDetails(nino.getOrElse(throw new NinoNotFoundOnAccount("")))
+        createApplePass <- createApplePassConnector.createApplePass(nino.get.formatted,
+                                                                    citizenDetails.person.completeName)
+        appleQRCode <- createApplePassConnector.getAppleQRCode(createApplePass)
+      } yield appleQRCode
     }
 
 }

--- a/app/uk/gov/hmrc/customerprofile/services/GooglePassService.scala
+++ b/app/uk/gov/hmrc/customerprofile/services/GooglePassService.scala
@@ -70,7 +70,7 @@ class GooglePassService @Inject() (
   def getGoogleQRCode(
   )(implicit hc:      HeaderCarrier,
     executionContext: ExecutionContext
-  ): Future[RetrieveGooglePass] =
+  ): Future[Option[Array[Byte]]] =
     auditService.withAudit("googleQRCode", Map.empty) {
       for {
         nino           <- getNino()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -116,7 +116,8 @@ microservice {
 
     find-my-nino-add-to-wallet {
         host     = localhost
-        port     = 14005
+        port     = 14011  # Use this to stub apple and google pass creation
+        #port     = 14005 # Use this to create real apple and google pass locally
     }
 
     entity-resolver {

--- a/conf/live.routes
+++ b/conf/live.routes
@@ -16,4 +16,4 @@ GET         /apple-qr-code                                            uk.gov.hmr
 
 GET         /google-pass                                           uk.gov.hmrc.customerprofile.controllers.GooglePassController.getGooglePass(journeyId: JourneyId)
 
-GET         /google-qr-code                                            uk.gov.hmrc.customerprofile.controllers.ApplePassController.getGoogleQRCode(journeyId: JourneyId)
+GET         /google-qr-code                                            uk.gov.hmrc.customerprofile.controllers.GooglePassController.getGoogleQRCode(journeyId: JourneyId)

--- a/conf/live.routes
+++ b/conf/live.routes
@@ -12,4 +12,8 @@ POST        /profile/preferences/pending-email                     uk.gov.hmrc.c
 
 GET         /apple-pass                                            uk.gov.hmrc.customerprofile.controllers.ApplePassController.getApplePass(journeyId: JourneyId)
 
+GET         /apple-qr-code                                            uk.gov.hmrc.customerprofile.controllers.ApplePassController.getAppleQRCode(journeyId: JourneyId)
+
 GET         /google-pass                                           uk.gov.hmrc.customerprofile.controllers.GooglePassController.getGooglePass(journeyId: JourneyId)
+
+GET         /google-qr-code                                            uk.gov.hmrc.customerprofile.controllers.ApplePassController.getGoogleQRCode(journeyId: JourneyId)

--- a/test/uk/gov/hmrc/customerprofile/connector/ApplePassConnectorSpec.scala
+++ b/test/uk/gov/hmrc/customerprofile/connector/ApplePassConnectorSpec.scala
@@ -83,5 +83,37 @@ class ApplePassConnectorSpec extends HttpClientV2Helper {
         }
       }
     }
+
+    "calling the get QR code" should {
+
+      val bytes = "QRCode".getBytes
+      "return a Array of bytes given the call is successful" in {
+
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.successful(HttpResponse(200, "QRCode")))
+        connector.getAppleQRCode(passId) onComplete {
+          case Success(_) => Some(bytes)
+          case Failure(_) =>
+        }
+      }
+      "return 429 exception if the call is unsuccessful" in {
+
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.failed(new TooManyRequestException("")))
+        connector.getAppleQRCode(passId) onComplete {
+          case Success(_) => fail()
+          case Failure(_) =>
+        }
+      }
+      "return an exception if the call is unsuccessful" in {
+
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.failed(new BadRequestException("")))
+        connector.getAppleQRCode(passId) onComplete {
+          case Success(_) => fail()
+          case Failure(_) =>
+        }
+      }
+    }
   }
 }

--- a/test/uk/gov/hmrc/customerprofile/connector/GooglePassConnectorSpec.scala
+++ b/test/uk/gov/hmrc/customerprofile/connector/GooglePassConnectorSpec.scala
@@ -55,6 +55,7 @@ class GooglePassConnectorSpec extends HttpClientV2Helper {
         }
       }
     }
+
     "calling the getGooglePass" should {
       "return a base 64 encoded string given the call is successful" in {
         when(requestBuilderExecute[HttpResponse])
@@ -80,6 +81,39 @@ class GooglePassConnectorSpec extends HttpClientV2Helper {
           .thenReturn(Future.failed(new BadRequestException("")))
 
         connector.getGooglePassUrl(passId) onComplete {
+          case Success(_) => fail()
+          case Failure(_) =>
+        }
+      }
+    }
+
+    "calling the get Google qr code" should {
+
+      val bytes = "QRCode".getBytes
+      "return a Array of Bytes given the call is successful" in {
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.successful(HttpResponse(200, "QRCode")))
+
+        connector.getGoogleQRCode(passId) onComplete {
+          case Success(_) => Some(bytes)
+          case Failure(_) =>
+        }
+      }
+      "return 429 exception if the call is unsuccessful" in {
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.failed(new TooManyRequestException("")))
+
+        connector.getGoogleQRCode(passId) onComplete {
+          case Success(_) => fail()
+          case Failure(_) =>
+        }
+      }
+      "return an exception if the call is unsuccessful" in {
+
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.failed(new BadRequestException("")))
+
+        connector.getGoogleQRCode(passId) onComplete {
           case Success(_) => fail()
           case Failure(_) =>
         }

--- a/test/uk/gov/hmrc/customerprofile/services/ApplePassServiceSpec.scala
+++ b/test/uk/gov/hmrc/customerprofile/services/ApplePassServiceSpec.scala
@@ -61,5 +61,21 @@ class ApplePassServiceSpec extends BaseSpec {
       val result = await(service.getApplePass())
       result mustBe RetrieveApplePass(base64String)
     }
+
+    "audit and return an apple QR code" in {
+
+      val qrCode = "QRCode".getBytes()
+
+      when(accountAccessControl.retrieveNino()(any(), any())).thenReturn(Future.successful(Some(nino)))
+      when(auditService.withAudit[Option[Array[Byte]]](any(), any())(any())(any(), any()))
+        .thenReturn(Future.successful(Some(qrCode)))
+      when(citizenDetailsConnector.personDetails(any())(any(), any())).thenReturn(Future.successful(person2))
+      when(getApplePassConnector.createApplePass(any(), any())(any(), any())).thenReturn(Future.successful(passId))
+      when(getApplePassConnector.getAppleQRCode(any())(any(), any()))
+        .thenReturn(Future.successful(Some(qrCode)))
+
+      val result: Option[Array[Byte]] = await(service.getAppleQRCode())
+      result mustBe Some(qrCode)
+    }
   }
 }

--- a/test/uk/gov/hmrc/customerprofile/services/GooglePassServiceSpec.scala
+++ b/test/uk/gov/hmrc/customerprofile/services/GooglePassServiceSpec.scala
@@ -66,6 +66,21 @@ class GooglePassServiceSpec extends BaseSpec {
       result mustBe RetrieveGooglePass(googleKey)
     }
 
+    "audit and return a  google QR Code in Bytes" in {
+
+      val qrCode = "QRcode".getBytes()
+      when(accountAccessControl.retrieveNino()(any(), any())).thenReturn(Future.successful(Some(nino)))
+      when(auditService.withAudit[Option[Array[Byte]]](any(), any())(any())(any(), any()))
+        .thenReturn(Future.successful(Some(qrCode)))
+      when(citizenDetailsConnector.personDetails(any())(any(), any())).thenReturn(Future.successful(person2))
+      when(getGooglePassConnector.createGooglePassWithCredentials(any(), any(), any())(any(), any()))
+        .thenReturn(Future.successful(passId))
+      when(getGooglePassConnector.getGoogleQRCode(any())(any(), any()))
+        .thenReturn(Future.successful(Some(qrCode)))
+      val result = await(googlePassService.getGoogleQRCode())
+      result mustBe Some(qrCode)
+    }
+
   }
 
 }


### PR DESCRIPTION
two new api calls created - 
GET         /apple-qr-code                                            
GET         /google-qr-code 


These two apis were needed to generate QR code for ipad/tablet users since they don't have apple or google wallet on their ipds/tablets

The existing qr generate code  from find-my-nin0-add-to-wallet can;t be called as it need passId, So these new api calls will generate the passId and call qr generate code  from find-my-nin0-add-to-wallet internally.